### PR TITLE
Refine first set of hotkey bindings for Zoho CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,33 +19,53 @@ https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/
 
 ## Hotkey Overview
 
-| Task                                                                                      | Hotkey                       | Hotkey if outside of Zoho CRM |
-| ----------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------- |
-| [ ] Close the pop up small window                                                         | Escape                       |                               |
-| [x] Compose email (Question: Just a new one with empty recipent or to the marked record?) | Option + M                   |                               |
-| [ ] Convert to potential                                                                  | Option + C + O               |                               |
-| [ ] Create New Zoho CRM record, e.g. contact (C)                                          | Option + C + N               |                               |
-| [x] Delete current record                                                                 | Option + D                   |                               |
-| [x] Edit Zoho CRM record                                                                  | Option + E                   |                               |
-| [x] Global search                                                                         | ALT (Option-Key) + Space Bar |                               |
-| [x] Jump to Account Module                                                                | Option + Shift + A           | Option + Shift + A            |
-| [x] Jump to Contact Module                                                                | Option + Shift + C           | Option + Shift + C            |
-| [x] Jump to Deal Module                                                                   | Option + Shift + D           | Option + Shift + D            |
-| [x] Jump to Lead Module                                                                   | Option + Shift + L           | Option + Shift + L            |
-| [x] Jump to Menu Item 1                                                                   | Option + 1                   |                               |
-| [x] Jump to Menu Item 2                                                                   | Option + 2                   |                               |
-| [x] Jump to Menu Item 3                                                                   | Option + 3                   |                               |
-| [x] Jump to Menu Item 4                                                                   | Option + 4                   |                               |
-| [x] Jump to Menu Item 5                                                                   | Option + 5                   |                               |
-| [x] Jump to Menu Item 6                                                                   | Option + 6                   |                               |
-| [x] Jump to Menu Item 7                                                                   | Option + 7                   |                               |
-| [x] Jump to Menu Item 8                                                                   | Option + 8                   |                               |
-| [x] Jump to Menu Item 9                                                                   | Option + 9                   |                               |
-| [x] Jump to next entry in CRM records                                                     | Option + →                   |                               |
-| [x] Jump to previous entry in CRM records                                                 | Option + ←                   |                               |
-| [ ] Jump to notes in edit mode                                                            | Option + N + O               |                               |
-| [x] Save Zoho CRM record                                                                  | Option + S                   |                               |
+### Built-in Zoho CRM Hotkeys
 
+| Command           | Hotkey on PC Keyboard | Hotkey on Apple Keyboard |
+| ----------------- | --------------------- | ------------------------ |
+| [x] Global search | `alt + space`         | `option + space`         |
+
+### Navigation
+
+| Command                                   | Hotkey on PC Keyboard | Hotkey on Apple Keyboard |
+| ----------------------------------------- | --------------------- | ------------------------ |
+| [x] Jump to Menu Item 1                   | `1`                   | `1`                      |
+| [x] Jump to Menu Item 2                   | `2`                   | `2`                      |
+| [x] Jump to Menu Item 3                   | `3`                   | `3`                      |
+| [x] Jump to Menu Item 4                   | `4`                   | `4`                      |
+| [x] Jump to Menu Item 5                   | `5`                   | `5`                      |
+| [x] Jump to Menu Item 6                   | `6`                   | `6`                      |
+| [x] Jump to Menu Item 7                   | `7`                   | `7`                      |
+| [x] Jump to Menu Item 8                   | `8`                   | `8`                      |
+| [x] Jump to Menu Item 9                   | `9`                   | `9`                      |
+| [x] Jump to next entry in CRM records     | `→ (arrow right)`     | `→ (arrow right)`        |
+| [x] Jump to previous entry in CRM records | `← (arrow left)`      | `← (arrow left)`         |
+
+### Record Managment
+
+| Command                                          | Hotkey on PC Keyboard | Hotkey on Apple Keyboard |
+| ------------------------------------------------ | --------------------- | ------------------------ |
+| [ ] Convert to potential                         | `alt + c`             | `option + c`             |
+| [ ] Create New Zoho CRM record, e.g. contact (C) | `n`                   | `n`                      |
+| [ ] Delete current record                        | `alt + d`             | `option + d`             |
+| [x] Compose email for current record             | `alt + m`             | `option + m`             |
+| [x] Edit Zoho CRM record                         | `e`                   | `e`                      |
+| [x] Save Zoho CRM record                         | `alt + s`             | `option + s`             |
+
+### Hotkeys outside of any Zoho application
+
+| Command                    | Hotkey on PC Keyboard | Hotkey on Apple Keyboard |
+| -------------------------- | --------------------- | ------------------------ |
+| [x] Jump to Account Module | `alt + shift + a`     | `option + shift + a`     |
+| [x] Jump to Contact Module | `alt + shift + c`     | `option + shift + c`     |
+| [x] Jump to Deal Module    | `alt + shift + d`     | `option + shift + d`     |
+| [x] Jump to Lead Module    | `alt + shift + l`     | `option + shift + l`     |
+
+### Upcoming hotkeys
+
+| Task                           | Hotkey on PC Keyboard | Hotkey on Apple Keyboard |
+| ------------------------------ | --------------------- | ------------------------ |
+| [ ] Jump to notes in edit mode | `alt + n + o`         | `option + n + o`         |
 
 ## chrome web store
 
@@ -53,29 +73,28 @@ https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/
 
 > 'Better Hotkeys for Zoho CRM' provides easy keyboard hotkeys to make you the fastest Zoho CRM power user in your company.
 >
-> Feature Set
-> --
+> ## Feature Set
+>
 > - Quickly open a main Zoho CRM module in a new tab from anywhere
 > - Easy keyboard hotkeys for navigating through Zoho CRM and editing records
 > - Support for all Zoho CRM regions
 > - Privacy-oriented implementation stores minimum data (only when really necessary)
 > - Coming soon: Override and define custom key bindings for optimal personal usage
 
-> Non-Affiliation statement
-> --
+> ## Non-Affiliation statement
+>
 > This extension and the developers are not affiliated in any way with Zoho, meaning this extension is not official. The extension does not alter the Zoho CRM website's HTML, it merely adds hotkeys to trigger existing links and buttons.
 >
-> The official Zoho website can be found at https://www.zoho.com. 
+> The official Zoho website can be found at https://www.zoho.com.
 > "Zoho", Zoho logos, and other Zoho trademarks are trademarks or registered trademarks of Zoho Corporation or its affiliates in India, the U.S. and elsewhere.
 >
-> Privacy
-> ---
+> ## Privacy
+>
 > This extension only saves the zoho org id and zoho domain if given. The extension does not send data to any servers nor does it store more information than the zoho org id and zoho domain.
 >
 > Open Source Code: https://github.com/b310-digital/zoho-crm-hotkeys
 >
 > Zoho Brand information: https://www.zoho.com/branding/
-
 
 ### Logos
 
@@ -100,6 +119,7 @@ PNG
 ![Logo](/public/images/zoho_better_hotkeys_icon.png)
 
 ### Screenshots (1-5)
+
 Should have...
 
 - Square corners, no padding (full bleed)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/
 
 | Command                                          | Hotkey on PC Keyboard | Hotkey on Apple Keyboard |
 | ------------------------------------------------ | --------------------- | ------------------------ |
-| [ ] Convert to potential                         | `alt + c`             | `option + c`             |
-| [ ] Create New Zoho CRM record, e.g. contact (C) | `n`                   | `n`                      |
-| [ ] Delete current record                        | `alt + d`             | `option + d`             |
+| [x] Convert to potential                         | `alt + c`             | `option + c`             |
+| [x] Create New Zoho CRM record, e.g. contact (C) | `n`                   | `n`                      |
+| [x] Delete current record                        | `alt + d`             | `option + d`             |
 | [x] Compose email for current record             | `alt + m`             | `option + m`             |
 | [x] Edit Zoho CRM record                         | `e`                   | `e`                      |
 | [x] Save Zoho CRM record                         | `alt + s`             | `option + s`             |

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -22,10 +22,12 @@ const mapping = {
   "8": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(8)",
   "9": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(9)",
   "e": "button#editRecordbtn", // prettier-ignore
+  "n": "#table_row_1 > lyte-td.alignRight > span.customPluswithImpotBtnCon.pR.cPlusImportButton.vam > link-to > button", // prettier-ignore
   // The following hot might not work on all circumstances. We should do some proper testing here.
   // We should find more explicit identifiers.
   // <a href="javascript:;" name="Delete2" data-zcqa="dvdeleteEntity" data-cid="deleteEntity" data-params="{&quot;module&quot;:&quot;Accounts&quot;,&quot;id&quot;:&quot;510691000000348104&quot;}">Delete</a>
   "alt+d": "a[data-cid=deleteEntity]",
+  "alt+c": "#conLink[data-zcqa=convert] > button",
   "alt+m": "#sendEntityMailLink",
   "alt+s": "button#crm_create_savebutn",
   "left": "img#detailPrevious", // prettier-ignore

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -12,33 +12,24 @@ const hotKeyCommand = new HotkeyCommand("");
 console.log(hotKeyCommand);
 
 const mapping = {
-  "alt+1":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(1)",
-  "alt+2":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(2)",
-  "alt+3":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(3)",
-  "alt+4":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(4)",
-  "alt+5":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(5)",
-  "alt+6":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(6)",
-  "alt+7":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(7)",
-  "alt+8":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(8)",
-  "alt+9":
-    "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(9)",
-  // "alt+e": "button#editRecordbtn",
-  "alt+s": "button#crm_create_savebutn",
+  "1": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(1)",
+  "2": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(2)",
+  "3": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(3)",
+  "4": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(4)",
+  "5": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(5)",
+  "6": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(6)",
+  "7": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(7)",
+  "8": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(8)",
+  "9": "crm-menu > div.crmMenuLeft.fL > crm-tab > div.lyteMenuItems > div:nth-child(9)",
+  "e": "button#editRecordbtn", // prettier-ignore
   // The following hot might not work on all circumstances. We should do some proper testing here.
   // We should find more explicit identifiers.
   // <a href="javascript:;" name="Delete2" data-zcqa="dvdeleteEntity" data-cid="deleteEntity" data-params="{&quot;module&quot;:&quot;Accounts&quot;,&quot;id&quot;:&quot;510691000000348104&quot;}">Delete</a>
   "alt+d": "a[data-cid=deleteEntity]",
-  "alt+left": "img#detailPrevious",
-  "alt+right": "img#detailNext",
   "alt+m": "#sendEntityMailLink",
+  "alt+s": "button#crm_create_savebutn",
+  "left": "img#detailPrevious", // prettier-ignore
+  "right": "img#detailNext", // prettier-ignore
 };
 
 Object.entries(mapping).forEach(([hotkey, xpath]) => {
@@ -54,49 +45,4 @@ Object.entries(mapping).forEach(([hotkey, xpath]) => {
     }
     event.preventDefault;
   });
-});
-
-// hotkeys("alt+n", (event, handler) => {
-//   if (location.href.includes("Accounts")) {
-//     return;
-//   }
-
-//   location.href = "https://crm.zoho.eu/crm/tab/Accounts/create";
-// });
-
-hotkeys("alt+e", (event, handler) => {
-  if (location.href.includes("Accounts")) {
-    return;
-  }
-
-  location.href = "https://crm.zoho.eu/crm/tab/Accounts/edit";
-});
-
-hotkeys("shift+alt+a", (event, handler) => {
-  if (location.href.includes("Accounts")) {
-    return;
-  }
-
-  location.href = "https://crm.zoho.eu/crm/tab/Accounts";
-});
-
-hotkeys("shift+alt+c", (event, handler) => {
-  if (location.href.includes("Contacts")) {
-    return;
-  }
-  location.href = "https://crm.zoho.eu/crm/tab/Contacts";
-});
-
-hotkeys("shift+alt+d", (event, handler) => {
-  if (location.href.includes("Deals")) {
-    return;
-  }
-  location.href = "https://crm.zoho.eu/crm/tab/Deals";
-});
-
-hotkeys("shift+alt+l", (event, handler) => {
-  if (location.href.includes("Leads")) {
-    return;
-  }
-  location.href = "https://crm.zoho.eu/crm/tab/Leads";
 });


### PR DESCRIPTION
## Further Notes

- After a discussion with @JannikStreek, we decided to simplify the hotkeys even more and define single character hotkeys, e.g. `e` hotkey for edit Zoho record

## New Features / Enhancements

- [x] Finalized the list of hotkeys, see `README.md`
- [x] Simplified hotkeys for operations that do not do state changes
- [x] Added hotkey for converting leads and creating new Zoho CRM records

## After Merge Checklist


